### PR TITLE
Remove inheritance from GPXTrackPoint (formerly Location) from RoutePoint, rename Location to GPXTrackPoint 

### DIFF
--- a/TopomapperNZ.xcodeproj/project.pbxproj
+++ b/TopomapperNZ.xcodeproj/project.pbxproj
@@ -23,19 +23,19 @@
 		A86508D42C3B591D0091EE0D /* RouteContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86508D32C3B591D0091EE0D /* RouteContent.swift */; };
 		A86508D72C3B60360091EE0D /* Statistic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86508D62C3B60360091EE0D /* Statistic.swift */; };
 		A86508D92C3B695C0091EE0D /* RoutePoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86508D82C3B695C0091EE0D /* RoutePoint.swift */; };
-		A86508DB2C3B6A8B0091EE0D /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86508DA2C3B6A8B0091EE0D /* Location.swift */; };
+		A86508DB2C3B6A8B0091EE0D /* GPXTrackPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86508DA2C3B6A8B0091EE0D /* GPXTrackPoint.swift */; };
 		A86508DE2C3B6D460091EE0D /* CLLocationCoordinate2D+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86508DD2C3B6D460091EE0D /* CLLocationCoordinate2D+Codable.swift */; };
 		A86508E02C3B6FEF0091EE0D /* RoutesSidebarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86508DF2C3B6FEF0091EE0D /* RoutesSidebarViewModel.swift */; };
 		A86508E22C3B8C630091EE0D /* GPXParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86508E12C3B8C630091EE0D /* GPXParser.swift */; };
 		A8CA0BD52C3BB8F0007035F7 /* Route+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BD42C3BB8F0007035F7 /* Route+Equatable.swift */; };
 		A8CA0BD72C3BB91C007035F7 /* Route+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BD62C3BB91C007035F7 /* Route+Hashable.swift */; };
 		A8CA0BD92C3BBE30007035F7 /* Route+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BD82C3BBE30007035F7 /* Route+Codable.swift */; };
+		A8CA0BDD2C3BD5B9007035F7 /* NewRouteSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BDC2C3BD5B9007035F7 /* NewRouteSheet.swift */; };
+		A8CA0BE12C3BE934007035F7 /* NewRouteSheet+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BE02C3BE934007035F7 /* NewRouteSheet+Actions.swift */; };
 		A8CA0BEA2C3BF887007035F7 /* [RoutePoint]+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BE92C3BF887007035F7 /* [RoutePoint]+Initializers.swift */; };
 		A8CA0BEC2C3BFA44007035F7 /* CLLocation+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BEB2C3BFA44007035F7 /* CLLocation+Initializers.swift */; };
 		A8CA0BEE2C3BFADB007035F7 /* CLLocationCoordinate2D+Distance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BED2C3BFADB007035F7 /* CLLocationCoordinate2D+Distance.swift */; };
-		A8CA0BF02C3BFBBA007035F7 /* Location+Distance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BEF2C3BFBBA007035F7 /* Location+Distance.swift */; };
-		A8CA0BDD2C3BD5B9007035F7 /* NewRouteSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BDC2C3BD5B9007035F7 /* NewRouteSheet.swift */; };
-		A8CA0BE12C3BE934007035F7 /* NewRouteSheet+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BE02C3BE934007035F7 /* NewRouteSheet+Actions.swift */; };
+		A8CA0BF02C3BFBBA007035F7 /* GPXTrackPoint+Distance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA0BEF2C3BFBBA007035F7 /* GPXTrackPoint+Distance.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,19 +75,19 @@
 		A86508D32C3B591D0091EE0D /* RouteContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteContent.swift; sourceTree = "<group>"; };
 		A86508D62C3B60360091EE0D /* Statistic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Statistic.swift; sourceTree = "<group>"; };
 		A86508D82C3B695C0091EE0D /* RoutePoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePoint.swift; sourceTree = "<group>"; };
-		A86508DA2C3B6A8B0091EE0D /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
+		A86508DA2C3B6A8B0091EE0D /* GPXTrackPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXTrackPoint.swift; sourceTree = "<group>"; };
 		A86508DD2C3B6D460091EE0D /* CLLocationCoordinate2D+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate2D+Codable.swift"; sourceTree = "<group>"; };
 		A86508DF2C3B6FEF0091EE0D /* RoutesSidebarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesSidebarViewModel.swift; sourceTree = "<group>"; };
 		A86508E12C3B8C630091EE0D /* GPXParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXParser.swift; sourceTree = "<group>"; };
 		A8CA0BD42C3BB8F0007035F7 /* Route+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route+Equatable.swift"; sourceTree = "<group>"; };
 		A8CA0BD62C3BB91C007035F7 /* Route+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route+Hashable.swift"; sourceTree = "<group>"; };
 		A8CA0BD82C3BBE30007035F7 /* Route+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route+Codable.swift"; sourceTree = "<group>"; };
+		A8CA0BDC2C3BD5B9007035F7 /* NewRouteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewRouteSheet.swift; sourceTree = "<group>"; };
+		A8CA0BE02C3BE934007035F7 /* NewRouteSheet+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NewRouteSheet+Actions.swift"; sourceTree = "<group>"; };
 		A8CA0BE92C3BF887007035F7 /* [RoutePoint]+Initializers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "[RoutePoint]+Initializers.swift"; sourceTree = "<group>"; };
 		A8CA0BEB2C3BFA44007035F7 /* CLLocation+Initializers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocation+Initializers.swift"; sourceTree = "<group>"; };
 		A8CA0BED2C3BFADB007035F7 /* CLLocationCoordinate2D+Distance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate2D+Distance.swift"; sourceTree = "<group>"; };
-		A8CA0BEF2C3BFBBA007035F7 /* Location+Distance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Location+Distance.swift"; sourceTree = "<group>"; };
-		A8CA0BDC2C3BD5B9007035F7 /* NewRouteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewRouteSheet.swift; sourceTree = "<group>"; };
-		A8CA0BE02C3BE934007035F7 /* NewRouteSheet+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NewRouteSheet+Actions.swift"; sourceTree = "<group>"; };
+		A8CA0BEF2C3BFBBA007035F7 /* GPXTrackPoint+Distance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GPXTrackPoint+Distance.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -228,7 +228,7 @@
 			children = (
 				A86508CF2C3B54590091EE0D /* Route.swift */,
 				A86508D82C3B695C0091EE0D /* RoutePoint.swift */,
-				A86508DA2C3B6A8B0091EE0D /* Location.swift */,
+				A86508DA2C3B6A8B0091EE0D /* GPXTrackPoint.swift */,
 				A86508E12C3B8C630091EE0D /* GPXParser.swift */,
 			);
 			path = Models;
@@ -249,7 +249,7 @@
 				A8CA0BE92C3BF887007035F7 /* [RoutePoint]+Initializers.swift */,
 				A8CA0BEB2C3BFA44007035F7 /* CLLocation+Initializers.swift */,
 				A8CA0BED2C3BFADB007035F7 /* CLLocationCoordinate2D+Distance.swift */,
-				A8CA0BEF2C3BFBBA007035F7 /* Location+Distance.swift */,
+				A8CA0BEF2C3BFBBA007035F7 /* GPXTrackPoint+Distance.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -411,11 +411,11 @@
 				A86508D02C3B54590091EE0D /* Route.swift in Sources */,
 				A86508E02C3B6FEF0091EE0D /* RoutesSidebarViewModel.swift in Sources */,
 				A8CA0BD72C3BB91C007035F7 /* Route+Hashable.swift in Sources */,
-				A8CA0BF02C3BFBBA007035F7 /* Location+Distance.swift in Sources */,
+				A8CA0BF02C3BFBBA007035F7 /* GPXTrackPoint+Distance.swift in Sources */,
 				A8CA0BEA2C3BF887007035F7 /* [RoutePoint]+Initializers.swift in Sources */,
 				A86508C32C3B4A600091EE0D /* Symbol.swift in Sources */,
 				A86508D72C3B60360091EE0D /* Statistic.swift in Sources */,
-				A86508DB2C3B6A8B0091EE0D /* Location.swift in Sources */,
+				A86508DB2C3B6A8B0091EE0D /* GPXTrackPoint.swift in Sources */,
 				A8CA0BE12C3BE934007035F7 /* NewRouteSheet+Actions.swift in Sources */,
 				A8CA0BD52C3BB8F0007035F7 /* Route+Equatable.swift in Sources */,
 				A86508D22C3B55530091EE0D /* Route+SampleData.swift in Sources */,

--- a/TopomapperNZ/Extensions/CLLocation+Initializers.swift
+++ b/TopomapperNZ/Extensions/CLLocation+Initializers.swift
@@ -9,10 +9,10 @@ import Foundation
 import CoreLocation
 
 extension CLLocation {
-    convenience init(from location: Location) {
+    convenience init(from gpxTrackPoint: GPXTrackPoint) {
         self.init(
-            latitude: location.coordinate.latitude,
-            longitude: location.coordinate.longitude
+            latitude: gpxTrackPoint.coordinate.latitude,
+            longitude: gpxTrackPoint.coordinate.longitude
         )
     }
 }

--- a/TopomapperNZ/Extensions/GPXTrackPoint+Distance.swift
+++ b/TopomapperNZ/Extensions/GPXTrackPoint+Distance.swift
@@ -1,5 +1,5 @@
 //
-//  Location+Distance.swift
+//  GPXTrackPoint+Distance.swift
 //  TopomapperNZ
 //
 //  Created by Derek Chai on 08/07/2024.
@@ -8,10 +8,10 @@
 import Foundation
 import CoreLocation
 
-extension Location {
-    func distance(from location: Location) -> CLLocationDistance {
+extension GPXTrackPoint {
+    func distance(from gpxTrackPoint: GPXTrackPoint) -> CLLocationDistance {
         let clLocation1 = CLLocation(from: self)
-        let clLocation2 = CLLocation(from: location)
+        let clLocation2 = CLLocation(from: gpxTrackPoint)
         
         return clLocation2.distance(from: clLocation1)
     }

--- a/TopomapperNZ/Extensions/Location+Distance.swift
+++ b/TopomapperNZ/Extensions/Location+Distance.swift
@@ -10,15 +10,8 @@ import CoreLocation
 
 extension Location {
     func distance(from location: Location) -> CLLocationDistance {
-        let clLocation1 = CLLocation(
-            latitude: self.coordinate.latitude,
-            longitude: self.coordinate.longitude
-        )
-        
-        let clLocation2 = CLLocation(
-            latitude: location.coordinate.latitude,
-            longitude: location.coordinate.longitude
-        )
+        let clLocation1 = CLLocation(from: self)
+        let clLocation2 = CLLocation(from: location)
         
         return clLocation2.distance(from: clLocation1)
     }

--- a/TopomapperNZ/Extensions/Location+Distance.swift
+++ b/TopomapperNZ/Extensions/Location+Distance.swift
@@ -10,6 +10,16 @@ import CoreLocation
 
 extension Location {
     func distance(from location: Location) -> CLLocationDistance {
-        return self.coordinate.distance(from: location.coordinate)
+        let clLocation1 = CLLocation(
+            latitude: self.coordinate.latitude,
+            longitude: self.coordinate.longitude
+        )
+        
+        let clLocation2 = CLLocation(
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude
+        )
+        
+        return clLocation2.distance(from: clLocation1)
     }
 }

--- a/TopomapperNZ/Extensions/[RoutePoint]+Initializers.swift
+++ b/TopomapperNZ/Extensions/[RoutePoint]+Initializers.swift
@@ -36,7 +36,13 @@ extension [RoutePoint] {
             
             distanceFromStart += distanceFromPreviousLocation
             
-            let grade = elevationChangeFromPreviousLocation / distanceFromPreviousLocation
+            let grade: Double
+            
+            if distanceFromPreviousLocation > 0 {
+                grade = elevationChangeFromPreviousLocation / distanceFromPreviousLocation
+            } else {
+                grade = 0
+            }
             
             let routePoint = RoutePoint(
                 location: location,

--- a/TopomapperNZ/Extensions/[RoutePoint]+Initializers.swift
+++ b/TopomapperNZ/Extensions/[RoutePoint]+Initializers.swift
@@ -19,7 +19,8 @@ extension [RoutePoint] {
         for location in locations {
             guard let previousLocation else {
                 let routePoint = RoutePoint(
-                    location: location,
+                    coordinate: location.coordinate,
+                    elevation: location.elevation,
                     distanceFromStart: 0,
                     grade: 0
                 )
@@ -45,7 +46,8 @@ extension [RoutePoint] {
             }
             
             let routePoint = RoutePoint(
-                location: location,
+                coordinate: location.coordinate,
+                elevation: location.elevation,
                 distanceFromStart: distanceFromStart,
                 grade: grade
             )

--- a/TopomapperNZ/Extensions/[RoutePoint]+Initializers.swift
+++ b/TopomapperNZ/Extensions/[RoutePoint]+Initializers.swift
@@ -9,45 +9,45 @@ import Foundation
 import CoreLocation
 
 extension [RoutePoint] {
-    init(from locations: [Location]) {
+    init(from gpxTrackPoints: [GPXTrackPoint]) {
         var distanceFromStart: CLLocationDistance = 0
         
-        var previousLocation: Location? = nil
+        var previousTrackPoint: GPXTrackPoint? = nil
         
         var output: [RoutePoint] = []
         
-        for location in locations {
-            guard let previousLocation else {
+        for trackPoint in gpxTrackPoints {
+            guard let previousTrackPoint else {
                 let routePoint = RoutePoint(
-                    coordinate: location.coordinate,
-                    elevation: location.elevation,
+                    coordinate: trackPoint.coordinate,
+                    elevation: trackPoint.elevation,
                     distanceFromStart: 0,
                     grade: 0
                 )
                 
                 output.append(routePoint)
                 
-                previousLocation = location
+                previousTrackPoint = trackPoint
                 
                 continue
             }
             
-            let distanceFromPreviousLocation = location.distance(from: previousLocation)
-            let elevationChangeFromPreviousLocation = location.elevation - previousLocation.elevation
+            let distanceFromPreviousTrackPoint = trackPoint.distance(from: previousTrackPoint)
+            let elevationChangeFromPreviousTrackPoint = trackPoint.elevation - previousTrackPoint.elevation
             
-            distanceFromStart += distanceFromPreviousLocation
+            distanceFromStart += distanceFromPreviousTrackPoint
             
             let grade: Double
             
-            if distanceFromPreviousLocation > 0 {
-                grade = elevationChangeFromPreviousLocation / distanceFromPreviousLocation
+            if distanceFromPreviousTrackPoint > 0 {
+                grade = elevationChangeFromPreviousTrackPoint / distanceFromPreviousTrackPoint
             } else {
                 grade = 0
             }
             
             let routePoint = RoutePoint(
-                coordinate: location.coordinate,
-                elevation: location.elevation,
+                coordinate: trackPoint.coordinate,
+                elevation: trackPoint.elevation,
                 distanceFromStart: distanceFromStart,
                 grade: grade
             )

--- a/TopomapperNZ/Models/GPXParser.swift
+++ b/TopomapperNZ/Models/GPXParser.swift
@@ -9,13 +9,13 @@ import Foundation
 import CoreLocation
 
 final class GPXParser: NSObject, XMLParserDelegate {
-    private var locations: [Location] = []
+    private var trackPoints: [GPXTrackPoint] = []
     private var currentElement: String = ""
-    private var currentLocation: Location?
+    private var currentTrackPoint: GPXTrackPoint?
     private var temporaryCoordinate: CLLocationCoordinate2D?
     
     // MARK: - Functions
-    func parsed(at url: URL) throws -> [Location] {
+    func parsed(at url: URL) throws -> [GPXTrackPoint] {
         guard let xmlParser = XMLParser(contentsOf: url) else {
             throw ParsingError.unableToCreateXMLParser
         }
@@ -28,7 +28,7 @@ final class GPXParser: NSObject, XMLParserDelegate {
             throw ParsingError.failedToParseGPXFile
         }
         
-        return locations
+        return trackPoints
     }
     
     // MARK: - Delegate Methods
@@ -67,7 +67,7 @@ final class GPXParser: NSObject, XMLParserDelegate {
         
         guard let temporaryCoordinate else { return }
         
-        currentLocation = Location(
+        currentTrackPoint = GPXTrackPoint(
             coordinate: temporaryCoordinate,
             elevation: elevation
         )
@@ -82,9 +82,9 @@ final class GPXParser: NSObject, XMLParserDelegate {
     ) {
         guard elementName == "trkpt" else { return }
         
-        guard let currentLocation else { return }
+        guard let currentTrackPoint else { return }
         
-        locations.append(currentLocation)
+        trackPoints.append(currentTrackPoint)
     }
 }
 

--- a/TopomapperNZ/Models/GPXTrackPoint.swift
+++ b/TopomapperNZ/Models/GPXTrackPoint.swift
@@ -1,5 +1,5 @@
 //
-//  Location.swift
+//  GPXTrackPoint.swift
 //  TopomapperNZ
 //
 //  Created by Derek Chai on 08/07/2024.
@@ -8,7 +8,7 @@
 import Foundation
 import CoreLocation
 
-class Location: Codable {
+class GPXTrackPoint: Codable {
     let coordinate: CLLocationCoordinate2D
     let elevation: CLLocationDistance
     

--- a/TopomapperNZ/Models/RoutePoint.swift
+++ b/TopomapperNZ/Models/RoutePoint.swift
@@ -8,49 +8,16 @@
 import Foundation
 import CoreLocation
 
-class RoutePoint: Location {
+class RoutePoint: Codable {
+    let coordinate: CLLocationCoordinate2D
+    let elevation: CLLocationDistance
     let distanceFromStart: CLLocationDistance
     let grade: Double
     
-    // MARK: - Initializers
-    init(
-        coordinate: CLLocationCoordinate2D,
-        elevation: CLLocationDistance,
-        distanceFromStart: CLLocationDistance,
-        grade: Double
-    ) {
+    init(coordinate: CLLocationCoordinate2D, elevation: CLLocationDistance, distanceFromStart: CLLocationDistance, grade: Double) {
+        self.coordinate = coordinate
+        self.elevation = elevation
         self.distanceFromStart = distanceFromStart
         self.grade = grade
-        
-        super.init(coordinate: coordinate, elevation: elevation)
-    }
-    
-    init(
-        location: Location,
-        distanceFromStart: CLLocationDistance,
-        grade: Double
-    ) {
-        self.distanceFromStart = distanceFromStart
-        self.grade = grade
-        
-        super.init(
-            coordinate: location.coordinate,
-            elevation: location.elevation
-        )
-    }
-
-    required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.distanceFromStart = try container.decode(CLLocationDistance.self, forKey: .distanceFromStart)
-        self.grade = try container.decode(Double.self, forKey: .grade)
-        
-        // Decode the properties of the superclass Location
-        try super.init(from: decoder)
-    }
-    
-    // MARK: - Coding Keys
-    enum CodingKeys: String, CodingKey {
-        case distanceFromStart
-        case grade
     }
 }

--- a/TopomapperNZ/Scenes/Routes/NewRouteSheet+Actions.swift
+++ b/TopomapperNZ/Scenes/Routes/NewRouteSheet+Actions.swift
@@ -59,10 +59,10 @@ extension NewRouteSheet {
             return
         }
         
-        let locations: [Location]
+        let gpxTrackPoints: [GPXTrackPoint]
         
         do {
-            locations = try gpxParser.parsed(at: selectedFileURL)
+            gpxTrackPoints = try gpxParser.parsed(at: selectedFileURL)
         } catch {
             showErrorAlert(for: error, title: "This file could not be processed")
             selectedFileURL.stopAccessingSecurityScopedResource()
@@ -72,7 +72,7 @@ extension NewRouteSheet {
         let route = Route(
             name: routeName,
             creationDate: Date(),
-            points: [RoutePoint].init(from: locations)
+            points: [RoutePoint].init(from: gpxTrackPoints)
         )
         
         modelContext.insert(route)

--- a/TopomapperNZ/TopomapperNZApp.swift
+++ b/TopomapperNZ/TopomapperNZApp.swift
@@ -14,7 +14,7 @@ struct TopomapperNZApp: App {
         let schema = Schema([
             Route.self
         ])
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
 
         do {
             return try ModelContainer(for: schema, configurations: [modelConfiguration])


### PR DESCRIPTION
# Remove inheritance from GPXTrackPoint (formerly Location) from RoutePoint, rename Location to GPXTrackPoint 

Formerly, an error was thrown where the coding key for "distanceFromStart" was not found. Removing the inheritance from GPXTrackPoint (Location) seems to have fixed this issue.

Also renamed Location to GPXTrackPoint to better represent the use of the class as the "trkpt" data from a GPX file, and emphasize that it is not necessarily related to RoutePoint. 